### PR TITLE
updated for giltlab-runner 10.x naming changes

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -2,7 +2,7 @@
 
 - name: Apt repo is defined
   stat:
-    path: /etc/apt/sources.list.d/runner_gitlab-ci-multi-runner.list
+    path: /etc/apt/sources.list.d/runner_gitlab-runner.list
   register: apt_repo
 
 - name: Create temporary directory for GitLab repo download
@@ -13,7 +13,7 @@
 
 - name: Download GitLab repo installer
   get_url:
-    url: https://packages.gitlab.com/install/repositories/runner/gitlab-ci-multi-runner/script.deb.sh
+    url: https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh
     dest: "{{ t.path }}/script.deb.sh"
     mode: '0755'
   environment: "{{ gitlab_runner_proxy_env }}"
@@ -22,14 +22,14 @@
 - name: Install GitLab repo
   command: "{{ t.path }}/script.deb.sh"
   args:
-    creates: /etc/apt/sources.list.d/runner_gitlab-ci-multi-runner.list
+    creates: /etc/apt/sources.list.d/runner_gitlab-runner.list
   environment: "{{ gitlab_runner_proxy_env }}"
   when: not apt_repo.stat.exists
   become: yes
 
 - name: Install GitLab runner
   package:
-    name: gitlab-ci-multi-runner
+    name: gitlab-runner
     state: latest
   environment: "{{ gitlab_runner_proxy_env }}"
   become: yes

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -20,11 +20,11 @@
 - name: RHEL Install GitLab Repo
   yum_repository:
     description: GitLab Runner Repo
-    name: runner_gitlab-ci-multi-runner
-    baseurl: "https://packages.gitlab.com/runner/gitlab-ci-multi-runner/el/{{ ansible_distribution_major_version }}/$basearch"
+    name: runner_gitlab-runner
+    baseurl: "https://packages.gitlab.com/runner/gitlab-runner/el/{{ ansible_distribution_major_version }}/$basearch"
     repo_gpgcheck: yes
     gpgcheck: no
-    gpgkey: https://packages.gitlab.com/runner/gitlab-ci-multi-runner/gpgkey
+    gpgkey: https://packages.gitlab.com/runner/gitlab-runner/gpgkey
     sslverify: yes
     sslcacert: /etc/pki/tls/certs/ca-bundle.crt
   notify:
@@ -33,7 +33,7 @@
 
 - name: RHEL Install GitLab runner
   package:
-    name: gitlab-ci-multi-runner
+    name: gitlab-runner
     state: latest
   environment: "{{ gitlab_runner_proxy_env }}"
   become: yes


### PR DESCRIPTION
Hi there, 

I've made changes to reflect the new 10.x git-runner file name changes as your role will only install version 9.x runners.

Only tested on Redhat/Centos

Stephen...